### PR TITLE
Fix Game activity crashing when checking last set

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "app.blef.blef"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 12
-        versionName "1.6.0"
+        versionCode 13
+        versionName "1.6.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="app.blef.blef"
-    android:versionCode="12"
-    android:versionName="1.6.0">
+    android:versionCode="13"
+    android:versionName="1.6.1">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/app/src/main/java/app/blef/blef/Game.kt
+++ b/app/src/main/java/app/blef/blef/Game.kt
@@ -483,7 +483,7 @@ class Game : AppCompatActivity() {
         checkButton.text = getString(R.string.check)
         checkButton.setOnClickListener {
             sendAction(88)
-            findViewById<PowerSpinnerView>(0).dismiss()
+            findViewById<PowerSpinnerView>(0)?.dismiss()
         }
 
         val startButton = BlefButton(this@Game)


### PR DESCRIPTION
Currently, the Game activity crashes (the app doesn't close, but the activity finishes) when trying to check the great straight flush of spades. That's because, on check button press, the app forcibly closes the set chooser, but in this case there is no set chooser to begin with.