### PR TITLE
Handle most of WebView burden at the end of the Main Activity startup

### DIFF
--- a/app/src/main/java/app/blef/blef/MainActivity.kt
+++ b/app/src/main/java/app/blef/blef/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.webkit.WebSettings
 import android.widget.*
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
@@ -199,5 +200,6 @@ class MainActivity : AppCompatActivity() {
                 }
             })
         }
+        Thread{ WebSettings.getDefaultUserAgent(this@MainActivity) }.start()
     }
 }


### PR DESCRIPTION
When the user moves to the Game activity for the first time after starting the app manually, the Game activity's onCreate execution time will be faster (from almost 500ms to almost 300ms on simulated Pixel 3a) because the Main Activity has handled most of the WebView burden in a background thread after it loaded.
If the user has already been to the game activity, it launches very quick and this PR doesn't change this.
If the user moves to the Game activity from an invite link, this PR doesn't change anything either.